### PR TITLE
Check Fb login status before opening a popup

### DIFF
--- a/lib/torii/providers/facebook-connect.js
+++ b/lib/torii/providers/facebook-connect.js
@@ -36,15 +36,21 @@ function fbLoad(settings){
 
 function fbLogin(scope, returnScopes, authType){
   return new Ember.RSVP.Promise(function(resolve, reject){
-    FB.login(function(response){
-      if (response.authResponse) {
+    FB.getLoginStatus(function (response) {
+      if (response.status === 'connected') {
         Ember.run(null, resolve, response.authResponse);
       } else {
-        Ember.run(null, reject, response.status);
+        FB.login(function (response) {
+          if (response.authResponse) {
+            Ember.run(null, resolve, response.authResponse);
+          } else {
+            Ember.run(null, reject, response.status);
+          }
+        }, {scope: scope, return_scopes: returnScopes, auth_type: authType});
       }
-    }, { scope: scope, return_scopes: returnScopes, auth_type: authType });
   });
 }
+
 
 function fbNormalize(response){
   var normalized = {


### PR DESCRIPTION
This checks the Facebook login status for fasbook-connect before opening a popup window.
This way the user doesn't get the short flash of the popup window.
